### PR TITLE
macos: set treatPackageAsDirectory flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,13 @@ Download the `.dmg` file and install it.
 
 You might have to add an exception to get it to open https://support.apple.com/guide/mac-help/open-a-mac-app-from-an-unidentified-developer-mh40616/mac
 
-#### NOTE: The DS9 installer for MacOS does not add the ds9 command-line executable to a standard path like /usr/local/bin. To get around that, please configure the archive-ds9-uri to use the ds9 executable located inside of the application package:
+**NOTE: The DS9 installer for MacOS does not add the ds9 command-line executable to a standard path like /usr/local/bin.
+To get around that, please configure the archive-ds9-uri to use the ds9 executable located inside of the application package:**
 
 1. Launch archive-ds9-uri
 2. Navigate to the preferences pane
-3. Under Preferences->DS9->Executable, click the folder to update the location of your DS9 executable. A finder window will open
-4. Type Command+Shift+g, a dialog should appear allowing you to navigate by path
-5. Navigate to /Applications/SAOImageDS9.app/Contents/MacOS. Hit enter. (Note for different versions of DS9 this path may be slightly different)
-6. A window with a single file, named ds9 should appear. Double-click the file to set it as your default ds9 executable.
+3. Under `Preferences->DS9->Executable`, click the folder to update the location of your DS9 executable. A finder window will open.
+4. Select `/Applications/SAOImageDS9.app/Contents/MacOS/ds9`. (Note for different versions of DS9 this path may be slightly different)
 
 ### Linux
 

--- a/src/renderer/Preferences.tsx
+++ b/src/renderer/Preferences.tsx
@@ -84,7 +84,7 @@ export const Preferences = ({ onClose }: PreferncesProps) => {
         const result = await window.main.showOpenDialog({
           title: "Select DS9 executable",
           buttonLabel: "Select",
-          properties: ["openFile"],
+          properties: ["openFile", "treatPackageAsDirectory"],
         });
 
         if (result.canceled) {


### PR DESCRIPTION
This should let users browser to DS9.app/Contents/MacOS/ds9 binary

#11 